### PR TITLE
Using FullName to prevent issues with the path environment variable

### DIFF
--- a/LoopbackAdapter.psm1
+++ b/LoopbackAdapter.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
    Install a new Loopback Network Adapter.
 .DESCRIPTION
-   Uses Chocolatey to download the DevCon (Windows Device Console) package and 
+   Uses Chocolatey to download the DevCon (Windows Device Console) package and
    uses it to install a new Loopback Network Adapter with the name specified.
    The Loopback Adapter will need to be configured like any other adapter (e.g. configure IP and DNS)
 .PARAMETER Name
@@ -28,7 +28,7 @@ function New-LoopbackAdapter
             Position=0)]
         [string]
         $Name,
-        
+
         [switch]
         $Force
     )
@@ -46,7 +46,7 @@ function New-LoopbackAdapter
     } # if
 
     # Make sure DevCon is installed.
-    $DevConExe = (Install-Devcon @PSBoundParameters).Name
+    $DevConExe = (Install-Devcon @PSBoundParameters).FullName
 
     # Get a list of existing Loopback adapters
     # This will be used to figure out which adapter was just added
@@ -172,7 +172,7 @@ function Get-LoopbackAdapter
 .SYNOPSIS
    Uninstall an existing Loopback Network Adapter.
 .DESCRIPTION
-   Uses Chocolatey to download the DevCon (Windows Device Console) package and 
+   Uses Chocolatey to download the DevCon (Windows Device Console) package and
    uses it to uninstall a new Loopback Network Adapter with the name specified.
 .PARAMETER Name
    The name of the Loopback Adapter to uninstall.
@@ -196,7 +196,7 @@ function Remove-LoopbackAdapter
             Position=0)]
         [string]
         $Name,
-        
+
         [switch]
         $Force
     )
@@ -222,7 +222,7 @@ function Remove-LoopbackAdapter
     } # if
 
     # Make sure DevCon is installed.
-    $DevConExe = (Install-Devcon @PSBoundParameters).Name
+    $DevConExe = (Install-Devcon @PSBoundParameters).FullName
 
     # Use Devcon.exe to remove the Microsoft Loopback adapter using the PnPDeviceID.
     # Requires local Admin privs.
@@ -241,8 +241,8 @@ function Remove-LoopbackAdapter
    The devcon.portable Chocolatey package can be found here and installed manually
    if no internet connection is available:
    https://chocolatey.org/packages/devcon.portable/
-   
-   Chocolatey will remain installed after this function is called.   
+
+   Chocolatey will remain installed after this function is called.
 .PARAMETER Force
    Force the install of Chocolatey and the Devcon.portable package if not already installed, without confirming with the user.
 .EXAMPLE
@@ -273,7 +273,7 @@ function Install-Devcon
         try
         {
             # This will download and install DevCon.exe
-            # It will also be automatically placed into the path 
+            # It will also be automatically placed into the path
             If ($Force -or $PSCmdlet.ShouldProcess('Download and install DevCon (Windows Device Console) using Chocolatey'))
             {
                 $null = & choco install -r -y devcon.portable
@@ -291,11 +291,11 @@ function Install-Devcon
 
     if ([Environment]::Is64BitOperatingSystem -eq $True)
     {
-        Get-ChildItem "$ENV:ProgramData\Chocolatey\Lib\devcon.portable\Devcon64.exe"    
+        Get-ChildItem "$ENV:ProgramData\Chocolatey\Lib\devcon.portable\Devcon64.exe"
     }
     else
     {
-        Get-ChildItem "$ENV:ProgramData\Chocolatey\Lib\devcon.portable\Devcon32.exe"    
+        Get-ChildItem "$ENV:ProgramData\Chocolatey\Lib\devcon.portable\Devcon32.exe"
     }
 }
 
@@ -306,7 +306,7 @@ function Install-Devcon
 .DESCRIPTION
    Installs Chocolatey from the internet if it is not installed, then uses
    it to uninstall the DevCon.Portable (Windows Device Console) package.
-   
+
    Chocolatey will remain installed after this function is called.
 .PARAMETER Force
    Force the uninstall of the devcon.portable package if it is installed, without confirming with the user.
@@ -328,18 +328,18 @@ function Uninstall-Devcon
         $Force
     )
     Install-Chocolatey @PSBoundParameters
-    
+
     try
     {
         # This will download and install DevCon.exe
-        # It will also be automatically placed into the path 
+        # It will also be automatically placed into the path
         if ($Force -or $PSCmdlet.ShouldProcess('Uninstall DevCon (Windows Device Console) using Chocolatey'))
         {
             $null = & choco uninstall -r -y devcon.portable
         }
         else
         {
-            Throw 'DevCon (Windows Device Console) was not uninstalled because user declined.'    
+            Throw 'DevCon (Windows Device Console) was not uninstalled because user declined.'
         }
     }
     catch
@@ -353,7 +353,7 @@ function Uninstall-Devcon
 .SYNOPSIS
    Install Chocolatey.
 .DESCRIPTION
-   Installs Chocolatey from the internet if it is not installed.d.   
+   Installs Chocolatey from the internet if it is not installed.d.
 .PARAMETER Force
    Force the install of Chocolatey, without confirming with the user.
 .EXAMPLE
@@ -379,7 +379,7 @@ function Install-Chocolatey
     {
         If ($Force -or $PSCmdlet.ShouldProcess('Download and install Chocolatey'))
         {
-            $null = Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))    
+            $null = Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
         }
         else
         {

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ LoopbackAdapter
 
 ## Versions
 
+### 1.2.1.0
+
+* Using FullName to prevent issues with the path environment variable
+
 ### 1.2.0.0
 
 * Cleanup README.MD markdown.


### PR DESCRIPTION
When invoking tests I was getting the following error:

```
Executing script .\Tests\Integration\MSFT_WinsServerAddress.Integration.Tests.ps1
  [-] Error occurred in test script '.\Tests\Integration\MSFT_WinsServerAddress.Integration.Tests.ps1' 0ms
    CommandNotFoundException: The term 'Devcon64.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
    at New-LoopbackAdapter, C:\Users\Administrator\Documents\WindowsPowerShell\Modules\LoopbackAdapter\LoopbackAdapter.psm1: line 57
    at New-IntegrationLoopbackAdapter, C:\Git\NetworkingDsc\Tests\Integration\IntegrationHelper.ps1: line 34
    at <ScriptBlock>, C:\Git\NetworkingDsc\Tests\Integration\MSFT_WinsServerAddress.Integration.Tests.ps1: line 27
    at <ScriptBlock>, C:\Program Files\WindowsPowerShell\Modules\Pester\4.8.1\Pester.psm1: line 1097
    at Invoke-Pester<End>, C:\Program Files\WindowsPowerShell\Modules\Pester\4.8.1\Pester.psm1: line 1123
```

This is because somehow Chololatey is not in my $env:Path variable. Switching from Name to FullName makes the module more robust and finds the exe regardless of the environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/loopbackadapter/9)
<!-- Reviewable:end -->
