### PR TITLE
Prevent errors from external resources not being ready

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "cSpell.words": [
+        "Devcon",
         "Loopback"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
-﻿{
+{
     // Use a custom PowerShell Script Analyzer settings file for this workspace.
     // Relative paths for this setting are always relative to the workspace root dir.
     "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
@@ -14,6 +14,9 @@
     "powershell.codeFormatting.ignoreOneLineBlock": false,
     "powershell.codeFormatting.preset": "Custom",
     "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true
+    "files.insertFinalNewline": true,
+    "cSpell.words": [
+        "Loopback"
+    ]
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix build problems preventing help from being compiled and added
   to the module.
 - Fix the XML help file output path.
-- Fix `Illegal operation attempted on a registry key that has been marked for
-  deletion.` error.
+- Fix "Illegal operation attempted on a registry key that has been marked for
+  deletion." error.
 
 ## [1.3.0] - 2020-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 - Added pipeline support to `Remove-LoopbackAdapter`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
-- Fix error generated from DevCon.exe still updating the registry.
+- Fix error generated from DevCon still updating the registry.
 - Fixed GitVersion to prevent build failures.
 - Convert build pipeline to use GitTools Azure DevOps extension tasks
   instead of deprecated GitVersion extension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix build problems preventing help from being compiled and added
   to the module.
 - Fix the XML help file output path.
+- Fix `Illegal operation attempted on a registry key that has been marked for
+  deletion.` error.
 
 ## [1.3.0] - 2020-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- Fix error generated from DevCon.exe still updating the registry.
 - Fixed GitVersion to prevent build failures.
 - Convert build pipeline to use GitTools Azure DevOps extension tasks
   instead of deprecated GitVersion extension.
 - Fix build problems preventing help from being compiled and added
   to the module.
 - Fix the XML help file output path.
-- Fix error generated from DevCon.exe still updating the registry.
 
 ## [1.3.0] - 2020-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix build problems preventing help from being compiled and added
   to the module.
 - Fix the XML help file output path.
-- Fix "Illegal operation attempted on a registry key that has been marked for
-  deletion." error.
+- Fix error generated from DevCon.exe still updating the registry.
 
 ## [1.3.0] - 2020-08-30
 

--- a/build.yaml
+++ b/build.yaml
@@ -50,7 +50,7 @@ BuildWorkflow:
         $PowerShellExe = 'powershell'
       }
 
-      & $PowerShellExe -Command "`"$execute`""
+      & $PowerShellExe -NoProfile -Command "`"$execute`""
     }
 
   '.':

--- a/source/Private/Wait-ForDevconUpdate.ps1
+++ b/source/Private/Wait-ForDevconUpdate.ps1
@@ -25,11 +25,11 @@ function Wait-ForDevconUpdate
     param
     (
         [Parameter()]
-        [System.Int]
+        [Int]
         $DevconExeTimeout = 5,
 
         [Parameter()]
-        [System.Int]
+        [Int]
         $RegistryUpdateTimeout = 5
     )
 

--- a/source/Private/Wait-ForDevconUpdate.ps1
+++ b/source/Private/Wait-ForDevconUpdate.ps1
@@ -1,0 +1,52 @@
+<#
+    .SYNOPSIS
+        Waits for changes made by DevCon.exe to complete before continuing.
+
+    .DESCRIPTION
+        Waits for the DevCon.exe process to exit and then checks whether Get-NetAdapter completes successfully.
+        Get-NetAdapter will throw "Illegal operation attempted on a registry key that has been marked for
+        deletion." if the changes are still processing.
+
+    .PARAMETER DevconExeTimeout
+        Time in seconds to wait for the DevCon process to complete.
+
+    .PARAMETER RegistryUpdateTimeout
+        Time in seconds to wait for the registry to finish processing changes.
+
+    .EXAMPLE
+        Wait-ForDevconUpdate
+
+    .NOTES
+        N/A
+#>
+function Wait-ForDevconUpdate
+{
+    [CmdletBinding()]
+    param
+    (
+        [int]$DevconExeTimeout = 5,
+        [int]$RegistryUpdateTimeout = 5
+    )
+
+    Get-Process -Name 'DevCon' -ErrorAction SilentlyContinue | Wait-Process -Timeout $DevconExeTimeout
+    $registryUpdated = $false
+    $registryTimer = 0
+    $waitIncrement = 500
+    while ($registryUpdated -eq $false)
+    {
+        try
+        {
+            Get-NetAdapter -ErrorAction Stop *>&1 | Out-Null
+            $registryUpdated = $true
+        }
+        catch [Microsoft.Management.Infrastructure.CimException]
+        {
+            if ($registryTimer -ge $RegistryUpdateTimeout * 1000)
+            {
+                throw $_
+            }
+            Start-Sleep -Milliseconds $waitIncrement
+            $registryTimer += $waitIncrement
+        }
+    }
+}

--- a/source/Private/Wait-ForDevconUpdate.ps1
+++ b/source/Private/Wait-ForDevconUpdate.ps1
@@ -24,28 +24,33 @@ function Wait-ForDevconUpdate
     [CmdletBinding()]
     param
     (
-        [int]$DevconExeTimeout = 5,
-        [int]$RegistryUpdateTimeout = 5
+        [Parameter()]
+        [System.Int]
+        $DevconExeTimeout = 5,
+
+        [Parameter()]
+        [System.Int]
+        $RegistryUpdateTimeout = 5
     )
 
     Get-Process -Name 'DevCon' -ErrorAction SilentlyContinue | Wait-Process -Timeout $DevconExeTimeout
     $registryUpdated = $false
     $registryTimer = 0
-    $waitIncrement = 500
+    $waitIncrement = 0.5
     while ($registryUpdated -eq $false)
     {
         try
         {
-            Get-NetAdapter -ErrorAction Stop *>&1 | Out-Null
+            $null = Get-NetAdapter -ErrorAction Stop *>&1
             $registryUpdated = $true
         }
         catch [Microsoft.Management.Infrastructure.CimException]
         {
-            if ($registryTimer -ge $RegistryUpdateTimeout * 1000)
+            if ($registryTimer -ge $RegistryUpdateTimeout)
             {
                 throw $_
             }
-            Start-Sleep -Milliseconds $waitIncrement
+            Start-Sleep -Seconds $waitIncrement
             $registryTimer += $waitIncrement
         }
     }

--- a/source/Public/New-LoopbackAdapter.ps1
+++ b/source/Public/New-LoopbackAdapter.ps1
@@ -42,25 +42,10 @@ function New-LoopbackAdapter
     #>
     Write-Verbose -Message ($LocalizedData.CreatingLoopbackAdapterMessage -f $Name)
     $null = & $DevConExe @('install', "$($ENV:SystemRoot)\inf\netloop.inf", '*MSLOOP')
-
-    <#
-        Don't continue until:
-        1. DevCon.exe has finished, and
-        2. The registry entry for the adapter has been updated (Get-NetAdapter throws if
-            used before that operation is done).
-    #>
-    Get-Process -Name 'DevCon' -ErrorAction SilentlyContinue | Wait-Process -Timeout 5
-    $adapters = @()
-    while (-not $adapters) {
-        try {
-            $adapters = Get-NetAdapter -Name '*' -ErrorAction Stop
-        }
-        catch {
-            Start-Sleep -Milliseconds 500
-        }
-    }
+    Wait-ForDevconUpdate
 
     # Find the newly added Loopback Adapter
+    $adapters = Get-NetAdapter
     $adapter = $adapters |
         Where-Object -FilterScript {
             ($_.PnPDeviceID -notin $ExistingAdapters ) -and `

--- a/source/Public/New-LoopbackAdapter.ps1
+++ b/source/Public/New-LoopbackAdapter.ps1
@@ -43,8 +43,24 @@ function New-LoopbackAdapter
     Write-Verbose -Message ($LocalizedData.CreatingLoopbackAdapterMessage -f $Name)
     $null = & $DevConExe @('install', "$($ENV:SystemRoot)\inf\netloop.inf", '*MSLOOP')
 
+    <#
+        Don't continue until:
+        1. DevCon.exe has finished, and
+        2. The registry entry for the adapter has been updated (Get-NetAdapter throws if
+            used before that operation is done).
+    #>
+    Get-Process -Name 'DevCon' -ErrorAction SilentlyContinue | Wait-Process -Timeout 5
+    $adapters = @()
+    while (-not $adapters) {
+        try {
+            $adapters = Get-NetAdapter -Name '*' -ErrorAction Stop
+        }
+        catch {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+
     # Find the newly added Loopback Adapter
-    $adapters = Get-NetAdapter
     $adapter = $adapters |
         Where-Object -FilterScript {
             ($_.PnPDeviceID -notin $ExistingAdapters ) -and `

--- a/source/Public/Remove-LoopbackAdapter.ps1
+++ b/source/Public/Remove-LoopbackAdapter.ps1
@@ -43,5 +43,26 @@ function Remove-LoopbackAdapter
         #>
         Write-Verbose -Message ($LocalizedData.RemovingLoopbackAdapterMessage -f $Name)
         $null = & $devConExe @('remove',"@$($adapter.PnPDeviceID)")
+
+        <#
+            Don't continue until:
+            1. DevCon.exe has finished, and
+            2. The registry entry for the adapter has been updated (Get-NetAdapter throws if
+               used before that operation is done).
+        #>
+        Get-Process -Name 'DevCon' -ErrorAction SilentlyContinue | Wait-Process -Timeout 5
+        $registryUpdated = $false
+        while (-not $registryUpdated) {
+            try {
+                $adapterToRemove = Get-NetAdapter -Name '*' -ErrorAction Stop |
+                    Where-Object -FilterScript { $_.PnPDeviceID -contains $adapter.PnPDeviceID }
+                if ($null -eq $adapterToRemove) {
+                    $registryUpdated = $true
+                }
+            }
+            catch {
+                Start-Sleep -Milliseconds 500
+            }
+        }
     }
 } # function Remove-LoopbackAdapter

--- a/tests/Integration/LoopbackAdapter.integration.Tests.ps1
+++ b/tests/Integration/LoopbackAdapter.integration.Tests.ps1
@@ -13,6 +13,15 @@ Import-Module -Name $ProjectName -Force
 Describe 'LoopbackAdapter Module' -Tag 'Integration' {
     BeforeAll {
         $script:testAdapterName = 'Test Loopback Adapter'
+        Get-LoopbackAdapter |
+            Where-Object -FilterScript { $_.Name -match $script:testAdapterName } |
+            Remove-LoopbackAdapter -Force
+    }
+
+    AfterAll {
+        Get-LoopbackAdapter |
+            Where-Object -FilterScript { $_.Name -match $script:testAdapterName } |
+            Remove-LoopbackAdapter -Force
     }
 
     Context 'When installing a Loopback Adapter' {
@@ -39,6 +48,26 @@ Describe 'LoopbackAdapter Module' -Tag 'Integration' {
 
         It 'Should have removed the loopback adapter' {
             Get-NetAdapter | Where-Object -FilterScript { $_.Name -eq  $script:testAdapterName } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When installing and removing multiple adapters' {
+        It 'should not throw an exception when using the same name' {
+            for ($i = 0; $i -lt 3; $i++) {
+                { New-LoopbackAdapter -Name $script:testAdapterName -Force | Remove-LoopbackAdapter -Force } |
+                    Should -Not -Throw
+            }
+        }
+
+        It 'should not throw an exception when removing several adapters at once' {
+            for ($i = 0; $i -lt 3; $i++) {
+                New-LoopbackAdapter -Name "$script:testAdapterName $($i + 1)" -Force
+            }
+            {
+                Get-LoopbackAdapter |
+                    Where-Object -FilterScript { $_.Name -match $script:testAdapterName } |
+                    Remove-LoopbackAdapter -Force
+            } | Should -Not -Throw
         }
     }
 }

--- a/tests/Unit/LoopbackAdapter.unit.Tests.ps1
+++ b/tests/Unit/LoopbackAdapter.unit.Tests.ps1
@@ -471,6 +471,18 @@ InModuleScope $ProjectName {
             )
         }
 
+        Context 'When the registry is updated right away' {
+            BeforeAll {
+                Mock -CommandName Get-NetAdapter -MockWith {
+                    $script:adaptersWithNoLoopbackAdapter_mock
+                }
+            }
+
+            It 'Should not throw an exception' {
+                { Wait-ForDevconUpdate } | Should -Not -Throw $script:registryError
+            }
+        }
+
         Context 'When the registry is not updated right away but then updates' {
             BeforeAll {
                 $script:getNetAdapterCounter = 0
@@ -486,8 +498,9 @@ InModuleScope $ProjectName {
                 }
             }
 
-            It 'Should not throw an exception' {
+            It 'Should catch the expected error and not throw an exception' {
                 { Wait-ForDevconUpdate } | Should -Not -Throw $script:registryError
+                $script:getNetAdapterCounter | Should -BeGreaterThan 0
             }
         }
 

--- a/tests/Unit/LoopbackAdapter.unit.Tests.ps1
+++ b/tests/Unit/LoopbackAdapter.unit.Tests.ps1
@@ -356,6 +356,11 @@ InModuleScope $ProjectName {
                     $Name -eq 'LoopbackAdapter'
                 }
             Mock -CommandName Get-NetAdapter
+            Mock -CommandName Get-NetAdapter `
+                -ParameterFilter {
+                    $Name -eq '*'
+                } `
+                -MockWith @script:adaptersWithNoLoopbackAdapter_mock
             Mock -CommandName Install-Devcon -MockWith {
                 @{
                     FullName = 'devcon'
@@ -394,9 +399,8 @@ InModuleScope $ProjectName {
                     $Name -eq 'LoopbackAdapter'
                 }
             Mock -CommandName Get-NetAdapter `
-                -MockWith @script:adaptersWithOneLoopbackAdapter_mock `
                 -ParameterFilter {
-                    $Name -eq 'LoopbackAdapter'
+                    $Name -eq '*'
                 }
             Mock -CommandName Install-Devcon -MockWith {
                 @{


### PR DESCRIPTION
# Pull Request

## Bug Fixes

- Fixes an issue where the registry has not been fully updated when doing multiple subsequent DevCon.exe operations, so it throws errors.

@PlagueHO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/loopbackadapter/26)
<!-- Reviewable:end -->
